### PR TITLE
fix on epel repo issue raised in #37 and #40

### DIFF
--- a/installer/auter_installer.yml
+++ b/installer/auter_installer.yml
@@ -34,16 +34,18 @@
         name: rs-epel-release
         state: latest
       when: epelPresent.stdout|int == 0
-      
+
     - name: add the epel repo
       tags:
         - auter
         - configsnap
-      when: ( '"No Package" in result.msg' ) and epelPresent.stdout == 0
+      when: >
+        epelPresent.stdout|int == 0 and
+        "no package" in result.msg | lower
       yum:
         name: epel-release
         state: latest
-      
+
     - name: install auter
       tags:
         - auter


### PR DESCRIPTION
From previous PR, change is I reverted the order of conditions to avoid hard fail when result has no msg.

Well it does not avoid it directly, but if any epel is already installed ( epelPresent.stdout|int != 0 ), then it will leave it there and skip the task.

Tested on RHEL 6 with and without prior epel-release installed.