### PR TITLE
Check that nimbus_path is not defined before checking the stat

### DIFF
--- a/installer/auter_installer.yml
+++ b/installer/auter_installer.yml
@@ -175,7 +175,7 @@
         - numbus
       set_fact:
         nimbus_path: "{{ nimbus_details.stat.path }}"
-      when: nimbus_details.stat.exists == True
+      when: nimbus_path is not defined and nimbus_details.stat.exists == True
 
     - name: Create nimbus monitors in "{{ nimbus_path }}"
       tags:


### PR DESCRIPTION
When the following is true:

```sh
$ ll /opt/
total 12
lrwxrwxrwx   1 root root       12 Jun 15  2016 nimbus -> /opt/nimsoft
drwxrwxr-x  11 root root     4096 Jun 15  2016 nimsoft
```

The task `set path variable to is /opt/nimsoft` will fail due to the
previous task updating the `nimbus_details` fact to:

```yaml
ok: [server.local] => {
  "msg": {
    "changed": false,
    "skip_reason": "Conditional result was False",
    "skipped": true
  }
}
```