### PR TITLE
Fix for #49: Nimbus install fails if nimbus and nimsoft are both present

### DIFF
--- a/roles/auter_installer/tasks/auter.yml
+++ b/roles/auter_installer/tasks/auter.yml
@@ -1,20 +1,17 @@
 ---
 
 - name: install auter
-  tags: auter
   yum:
     name: auter
     state: latest
 
 - name: adjust the auter.conf file
-  tags: configure
   template:
     backup: yes
     src: auter.conf.j2
     dest: /etc/auter/auter.conf
 
 - name: add warning to not edit yum.conf exclude manually
-  tags: configure
   lineinfile:
     backup: yes
     line: "# WARNING: the excludes line is edited by auter_installer everytime it is run"
@@ -22,7 +19,6 @@
     dest: /etc/yum.conf
 
 - name: adjust the yum.conf excludes
-  tags: configure
   lineinfile:
     backup: yes
     dest: /etc/yum.conf
@@ -31,14 +27,13 @@
     line: exclude={{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=1 delimiter=,') }}
 
 - name: check auter status
-  tags: auter
   shell: "auter --status"
   register: auterStatus
   changed_when: False
   # basically always return OK during execution
 
 - name: enable auter
-  tags: auter
   command: auter --enable
   when: "'auter is currently enabled' not in auterStatus.stdout"
 
+...

--- a/roles/auter_installer/tasks/configsnap.yml
+++ b/roles/auter_installer/tasks/configsnap.yml
@@ -1,13 +1,11 @@
 ---
 
 - name: Install configsnap
-  tags: configure,configsnap
   yum:
     name: configsnap
     state: latest
 
 - name: create configsnap pre apply script
-  tags: configure,configsnap
   lineinfile:
     create: yes
     state: present
@@ -17,7 +15,6 @@
     line: /usr/sbin/configsnap --silent -d /root -t auter-configsnap-$(date +%Y-%m-%d) -p pre
 
 - name: create configsnap post apply script
-  tags: configure,configsnap
   lineinfile:
     create: yes
     state: present
@@ -27,13 +24,11 @@
     line: /usr/sbin/configsnap -d /root -t auter-configsnap-$(date +%Y-%m-%d) -p post-update &> /root/auter-configsnap-$(date +%Y-%m-%d)/configsnap/post-update.compare
 
 - name: delete old configsnap pre reboot script if it exists
-  tags: configure,configsnap
   file:
     state: absent
     dest: /etc/auter/pre-reboot.d/99-configsnap-pre-reboot
 
 - name: create configsnap pre reboot script
-  tags: configure,configsnap
   blockinfile:
     backup: no
     create: yes
@@ -52,7 +47,6 @@
   no_log: true
 
 - name: create configsnap post reboot script
-  tags: configure,configsnap
   lineinfile:
     create: yes
     state: present
@@ -61,3 +55,4 @@
     regexp: configsnap.*post-reboot
     line: '/usr/sbin/configsnap -d /root -t auter-configsnap-$(date +%Y-%m-%d) -p post-reboot &> /root/auter-configsnap-$(date +%Y-%m-%d)/configsnap/post-reboot.compare'
 
+...

--- a/roles/auter_installer/tasks/main.yml
+++ b/roles/auter_installer/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Pre-check if server has configuration set in CSV file
-  tags: prechecks
+  tags:
+    - prechecks
+    - install
   become: False
   changed_when: False
   local_action: command grep ^{{ inventory_hostname.split(':')[0] }}, {{ csv_file }}
@@ -14,7 +16,10 @@
   # basically always return OK during execution
 
 - name: add the rs-epel repo
-  tags: auter,configsnap
+  tags:
+    - auter
+    - configsnap
+    - install
   failed_when: False
   register: result
   yum:
@@ -23,7 +28,10 @@
   when: epelPresent.stdout|int == 0
 
 - name: add the epel repo
-  tags: auter,configsnap
+  tags:
+    - auter
+    - configsnap
+    - install
   yum:
     name: epel-release
     state: latest
@@ -32,6 +40,18 @@
     "no package" in result.msg|lower
 
 - import_tasks: auter.yml
+  tags:
+    - auter
+    - install
 - import_tasks: configsnap.yml
+  tags:
+    - install
+    - configure
+    - configsnap
 - import_tasks: nimbus.yml
+  tags:
+    - install
+    - configure
+    - nimbus
 
+...

--- a/roles/auter_installer/tasks/nimbus.yml
+++ b/roles/auter_installer/tasks/nimbus.yml
@@ -2,35 +2,36 @@
 
 # This section can be used if you have nimbus installed and configured
 - name: Check if nimbus path is /opt/nimbus
-  tags: configure,nimbus
-  stat: path=/opt/nimbus/probes/system/logmon/logmon.cfg
+  stat: path=/opt/nimbus
   register: nimbus_details
 
 - name: set path variable to use /opt/nimbus
   tags: configure,nimbus
   set_fact:
     nimbus_path: "{{ nimbus_details.stat.path }}"
-  when: nimbus_details.stat.exists == True
+  when: >
+    nimbus_details.stat.exists == True
+    and nimbus_details.stat.islnk == False
 
 - name: check if nimbus path is /opt/nimsoft
-  tags: configure,nimbus
-  stat: path=/opt/nimsoft/probes/system/logmon/logmon.cfg
+  stat: path=/opt/nimsoft
   register: nimbus_details
   when: nimbus_path is not defined
 
-- name: set path variable to is /opt/nimsoft
-  tags: configure,nimbus
+- name: set path variable to use /opt/nimsoft
   set_fact:
     nimbus_path: "{{ nimbus_details.stat.path }}"
-  when: nimbus_details.stat.exists == True
+  when: >
+    nimbus_details.stat.exists == True
+    and nimbus_details.stat.islnk == False
 
-- name: Create nimbus monitors in "{{ nimbus_path }}"
-  tags: configure,nimbus
+- name: Create nimbus monitors in "{{ nimbus_path }}" if the file exists
   blockinfile:
     backup: yes
     insertbefore: "</profiles>"
     marker: "# {mark} ANSIBLE MANAGED AUTER BLOCK"
-    dest: /opt/nimsoft/probes/system/logmon/logmon.cfg
+    dest: "{{ nimbus_path }}/probes/system/logmon/logmon.cfg"
+    create: no
     block: |2
          <auter_monitors>
             active = yes
@@ -88,13 +89,11 @@
   when: nimbus_path is defined
 
 - name: get number of nimbus processes
-  tags: configure,nimbus
   shell: "ps aux | grep -c nimbus"
   register: nimbusProcessCountPre
   when: nimbus_path is defined and nimbus_updated.changed
 
 - name: restart nimbus
-  tags: configure,nimbus
   failed_when: False
   service:
     enabled: yes


### PR DESCRIPTION
Only proceed with nimbus configuration if at least one of `/opt/nimbus` and `/opt/nimsoft` is no a link.

Also, reorganizing tags and using explicit `create: no` option on the `blockinfile` (though default already).