### PR TITLE
yum excludes only handled if defined in csv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ Things to consider when filling the csv file:
 - `auter_reporter.yml` is an easy way to gather information on Auter status and latest use for any number of devices. The result file will be place into sub-directory **output**.
 
 ## Why csv format?
-Using the csv file should make it easy to keep configuration reference easily readable from a spreadsheet editor, so that it can be maintained by non-tech people.
+Using the csv file should make it easy to keep configuration reference easily readable from a spreadsheet editor, so that it can be maintained by non-tech people.  
 **note:** you should not add/remove any columns or the playbook execution will break. The csv file should suffice as the only source for Auter installation / configuration / scheduling.
 

--- a/roles/auter_installer/tasks/auter.yml
+++ b/roles/auter_installer/tasks/auter.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Pre-check if server has configuration set in CSV file for cron scheduling
+  tags: prechecks
+  become: False
+  changed_when: False
+  local_action: command grep ^{{ inventory_hostname.split(':')[0] }}, {{ csv_file }}
+
 - name: install auter
   yum:
     name: auter
@@ -11,12 +17,18 @@
     src: auter.conf.j2
     dest: /etc/auter/auter.conf
 
+- name: Check if csv contains yum excludes
+  tags: yum
+  set_fact:
+    yum_excludes: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=1 delimiter=,') }}"
+
 - name: add warning to not edit yum.conf exclude manually
   lineinfile:
     backup: yes
-    line: "# WARNING: the excludes line is edited by auter_installer everytime it is run"
+    line: "# WARNING: if set in the csv file, the excludes line is edited by auter_installer everytime it is run"
     insertbefore: "^exclude="
     dest: /etc/yum.conf
+  when: yum_excludes != ""
 
 - name: adjust the yum.conf excludes
   lineinfile:
@@ -24,7 +36,8 @@
     dest: /etc/yum.conf
     state: present
     regexp: ^exclude
-    line: exclude={{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=1 delimiter=,') }}
+    line: exclude={{ yum_excludes }}
+  when: yum_excludes != ""
 
 - name: check auter status
   shell: "auter --status"

--- a/roles/auter_installer/tasks/auter.yml
+++ b/roles/auter_installer/tasks/auter.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: Pre-check if server has configuration set in CSV file for cron scheduling
-  tags: prechecks
-  become: False
-  changed_when: False
-  local_action: command grep ^{{ inventory_hostname.split(':')[0] }}, {{ csv_file }}
-
 - name: install auter
   yum:
     name: auter
@@ -25,7 +19,7 @@
 - name: add warning to not edit yum.conf exclude manually
   lineinfile:
     backup: yes
-    line: "# WARNING: if set in the csv file, the excludes line is edited by auter_installer everytime it is run"
+    line: "# WARNING: if set in the csv file (non-empty value), the 'exclude' line is edited by auter_installer playbook everytime it is run."
     insertbefore: "^exclude="
     dest: /etc/yum.conf
   when: yum_excludes != ""

--- a/roles/auter_installer/tasks/main.yml
+++ b/roles/auter_installer/tasks/main.yml
@@ -1,43 +1,9 @@
 ---
 
-- name: Pre-check if server has configuration set in CSV file
+- import_tasks: prepare.yml
   tags:
     - prechecks
-    - install
-  become: False
-  changed_when: False
-  local_action: command grep ^{{ inventory_hostname.split(':')[0] }}, {{ csv_file }}
-
-- name: Check if epel repo is present
-  tags: prechecks,auter,configsnap
-  shell: time yum repolist | grep epel | wc -l
-  register: epelPresent
-  changed_when: False
-  # basically always return OK during execution
-
-- name: add the rs-epel repo
-  tags:
-    - auter
-    - configsnap
-    - install
-  failed_when: False
-  register: result
-  yum:
-    name: rs-epel-release
-    state: latest
-  when: epelPresent.stdout|int == 0
-
-- name: add the epel repo
-  tags:
-    - auter
-    - configsnap
-    - install
-  yum:
-    name: epel-release
-    state: latest
-  when: >
-    epelPresent.stdout|int == 0 and
-    "no package" in result.msg|lower
+    - prepare
 
 - import_tasks: auter.yml
   tags:

--- a/roles/auter_installer/tasks/prepare.yml
+++ b/roles/auter_installer/tasks/prepare.yml
@@ -1,0 +1,41 @@
+---
+
+- name: Pre-check if server has configuration set in CSV file (for excludes)
+  become: False
+  changed_when: False
+  local_action: command grep ^{{ inventory_hostname.split(':')[0] }}, {{ csv_file }}
+
+- name: Check if epel repo is present
+  tags:
+    - auter
+    - configsnap
+  shell: time yum repolist | grep epel | wc -l
+  register: epelPresent
+  changed_when: False
+  # basically always return OK during execution
+
+- name: add the rs-epel repo
+  tags:
+    - auter
+    - configsnap
+    - install
+  failed_when: False
+  register: result
+  yum:
+    name: rs-epel-release
+    state: latest
+  when: epelPresent.stdout|int == 0
+
+- name: add the epel repo
+  tags:
+    - auter
+    - configsnap
+    - install
+  yum:
+    name: epel-release
+    state: latest
+  when: >
+    epelPresent.stdout|int == 0 and
+    "no package" in result.msg|lower
+
+...

--- a/roles/auter_scheduler/tasks/main.yml
+++ b/roles/auter_scheduler/tasks/main.yml
@@ -66,7 +66,7 @@
   tags: cron,prep
   set_fact:
     prep_day: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=7 delimiter=,').split(':')[0] | lower }}"
-  failed_when: prep_day == ""
+  failed_when: lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=7 delimiter=,') == ""
 
 ## APPLY check
 - name: Lookup schedule apply_hour from the CSV file
@@ -119,7 +119,7 @@
   tags: cron,apply
   set_fact:
     apply_day: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=10 delimiter=,').split(':')[0] | lower }}"
-  failed_when: apply_day == ""
+  failed_when: lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=10 delimiter=,') == ""
 
 ###########################################
 ## Pre-checks have been done, going forward

--- a/roles/auter_scheduler/tasks/main.yml
+++ b/roles/auter_scheduler/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Control if variable 'reboot' is not easily assimilable to a boolean
   tags: prechecks,apply
   assert:
@@ -15,30 +17,16 @@
   changed_when: False
   local_action: command grep ^{{ inventory_hostname.split(':')[0] }}, {{ csv_file }}
 
-## PREP check
+## PREP facts
 - name: Lookup schedule prep_hour from the CSV file
   tags: prechecks,prep
   set_fact:
     prep_hour: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=6 delimiter=,').split(':')[0] }}"
 
-- name: Fail if server's schedule prep_hour is invalid
-  tags: prechecks,prep
-  fail:
-    msg: schedule prep_hour for {{ inventory_hostname }} is invalid
-  when:
-    prep_hour|int < 0 or prep_hour|int > 23
-
 - name: Lookup schedule prep_minute from the CSV file
   tags: prechecks,prep
   set_fact:
     prep_minute: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=6 delimiter=,').split(':')[1] }}"
-
-- name: Fail if server's schedule prep_minute is invalid
-  tags: prechecks,prep
-  fail:
-    msg: schedule prep_minute for {{ inventory_hostname }} is invalid
-  when:
-    prep_minute|int < 0 or prep_minute|int > 59
 
 - name: Lookup schedule prep_month from the CSV file
   tags: prechecks,prep
@@ -50,48 +38,21 @@
     prep_month: "*"
   when: prep_month == ""
 
-#- debug: var=prep_month
-#  tags: schedule
-#- debug: var=prep_month|regex_search('(^\*$)|^([1-9]|1[012])((\-([1-9]$|1[012]$))|(\,([1-9]|1[012]))+)')
-#  tags: schedule
-
-- name: Fail if server's schedule prep_month is invalid
-  tags: prechecks,prep
-  fail:
-    msg: schedule prep_month for {{ inventory_hostname }} is invalid
-  when:
-    prep_month|regex_search('(^\*$)|^([1-9]|1[012])((\-([1-9]$|1[012]$))|(\,([1-9]|1[012]))+)') != prep_month
-
 - name: == PREP == Lookup schedule day from the CSV file
   tags: cron,prep
   set_fact:
     prep_day: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=7 delimiter=,').split(':')[0] | lower }}"
-  failed_when: lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=7 delimiter=,') == ""
 
-## APPLY check
+## APPLY facts
 - name: Lookup schedule apply_hour from the CSV file
   tags: prechecks,apply
   set_fact:
     apply_hour: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=9 delimiter=,').split(':')[0] }}"
 
-- name: Fail if server's schedule apply_hour is invalid
-  tags: prechecks,apply
-  fail:
-    msg: schedule apply_hour for {{ inventory_hostname }} is invalid
-  when:
-    apply_hour|int < 0 or apply_hour|int > 23
-
 - name: Lookup schedule apply_minute from the CSV file
   tags: prechecks,apply
   set_fact:
     apply_minute: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=9 delimiter=,').split(':')[1] }}"
-
-- name: Fail if server's schedule apply_minute is invalid
-  tags: prechecks,apply
-  fail:
-    msg: schedule apply_minute for {{ inventory_hostname }} is invalid
-  when:
-    apply_minute|int < 0 or apply_minute|int > 59
 
 - name: Lookup schedule apply_month from the CSV file
   tags: prechecks,apply
@@ -103,23 +64,34 @@
     apply_month: "*"
   when: apply_month == ""
 
-#- debug: var=apply_month
-#  tags: schedule
-#- debug: var=apply_month|regex_search('(^\*$)|^([1-9]|1[012])((\-([1-9]$|1[012]$))|(\,([1-9]|1[012]))+)')
-#  tags: schedule
-
-- name: Fail if server's schedule apply_month is invalid
-  tags: prechecks,apply
-  fail:
-    msg: schedule apply_month for {{ inventory_hostname }} is invalid
-  when:
-    apply_month|regex_search('(^\*$)|^([1-9]|1[012])((\-([1-9]$|1[012]$))|(\,([1-9]|1[012]))+)') != apply_month
-
 - name: == APPLY == Lookup schedule day from the CSV file
   tags: cron,apply
   set_fact:
     apply_day: "{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=10 delimiter=,').split(':')[0] | lower }}"
-  failed_when: lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=10 delimiter=,') == ""
+
+###########################################
+## Pre-requisite assertions
+###########################################
+#- debug: var=apply_month
+#  tags: schedule
+#- debug:
+#    msg: "apply_month = {{ apply_month|regex_search('(^\\*$)|^([1-9]|1[012])((\\-([1-9]$|1[012]$))|(\\,([1-9]|1[012]))+|$)') }}"
+#  tags: schedule
+
+- name: check that cron-related variables are correctly set
+  assert:
+    that:
+      - prep_hour|int >= 0 and prep_hour|int <= 23
+      - prep_minute|int >= 0 and prep_minute|int <= 59
+      - prep_month|regex_search('(^\*$)|^([1-9]|1[012])($|(\-([1-9]$|1[012]$))|(\,([1-9]|1[012]))+)') == prep_month
+      - prep_day != ""
+      - apply_hour|int >= 0 and apply_hour|int <= 23
+      - apply_minute|int >= 0 and apply_minute|int <= 59
+      - apply_month|regex_search('(^\*$)|^([1-9]|1[012])($|(\-([1-9]$|1[012]$))|(\,([1-9]|1[012]))+)') == apply_month
+      - apply_day != ""
+    msg: "Could not validate the cron-related variables. Please check/correct the CSV file and try again."
+    #fail_msg: "Could not validate the cron-related variables. Please check/correct the CSV file and try again."
+    #success_msg: "Cron time variables from CSV look good."
 
 ###########################################
 ## Pre-checks have been done, going forward
@@ -129,8 +101,6 @@
   tags: cron,prep
   set_fact:
     prep_numberday: "{{ prep_day | regex_search('[1-9]+') }}"
-
-#- debug: var=prep_numberday
 
 - name: == PREP == Set up occurence variable if prep day is a labeled day
   tags: cron,prep
@@ -152,15 +122,10 @@
     prep_cron: '{ "description": "prep auter", "minute": "{{ prep_minute }}", "hour": "{{ prep_hour }}", "day": "{{ occur_cron[prep_occurrence] }}", "weekday": "*", "month": "{{ prep_month }}", "user": "root", "job": "[ $(date +\%u) -eq {{ day_cron[prep_day] }} ] &&  /usr/bin/auter --prep" }'
   when: prep_numberday == ""
 
-#- debug: var=prep_cron
-
 - name: Decide if we need to check for a weekday+occurrence or a fixed day of the month
   tags: cron,apply
   set_fact:
     apply_numberday: "{{ apply_day | regex_search('[0-9]+') }}"
-
-  #- debug: var=apply_numberday
-  #  tags: cron,apply
 
 - name: == APPLY == Set up occurence variable if apply day is a labeled day
   tags: cron,apply
@@ -180,8 +145,6 @@
   set_fact:
           apply_cron: '{ "description": "apply auter", "minute": "{{ apply_minute }}", "hour": "{{ apply_hour }}", "day": "{{ occur_cron[apply_occurrence] }}", "weekday": "*", "month": "{{ apply_month }}", "user": "root", "job": "[ $(date +\%u) -eq {{ day_cron[apply_day] }} ] &&  /usr/bin/auter --apply {{ forcereboot }}" }'
   when: apply_numberday == ""
-
-#- debug: var=apply_cron
 
 ## Splitting into two task so that we can use specific tags 'prep' or 'apply'
 - name: Add cron jobs as defined by the server's schedule group
@@ -213,3 +176,5 @@
     job: "{{ item.job }}"
   with_items:
     - "{{ apply_cron }}"
+
+...


### PR DESCRIPTION
This should avoid wiping out clean yum excludes when install auter if no excludes are set in the CSV file.

Also small fix for prep_day / apply_day.