### PR TITLE
fix csv variable issue for auter_installer when used standalone

### DIFF
--- a/auter_installer.yml
+++ b/auter_installer.yml
@@ -25,3 +25,4 @@
   roles:
     - auter_installer
 
+...

--- a/auter_manager.yml
+++ b/auter_manager.yml
@@ -17,14 +17,8 @@
       default: "./auter_config.csv"
       private: no
 
-  # Need to do this to get variables usable in both playbooks
-  pre_tasks:
-    - name: set variable csv_file for all plays
-      tags: install,schedule
-      set_fact:
-        csv_file: '{{ ini_csv_file }}'
-
   roles:
     - { role: auter_installer, tags: ['install'] }
     - { role: auter_scheduler, tags: ['schedule'] }
 
+...

--- a/roles/auter_installer/templates/auter.conf.j2
+++ b/roles/auter_installer/templates/auter.conf.j2
@@ -8,12 +8,12 @@ CONFIGSET="default"
 # Set whether server will reboot automatically after --apply. A warning
 # message will show for logged in users 2 mins before the reboot. The 
 # system will only be rebooted if an update was applied.
-AUTOREBOOT="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=2 delimiter=,') }}"
+AUTOREBOOT="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + ini_csv_file + ' col=2 delimiter=,') }}"
 
 # Options to pass to yum/dnf update. For example, this can be used to 
 # disable excludes or omit packages. If dnf is installed, it will be the
 # preferred package manager.
-PACKAGEMANAGEROPTIONS="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=3 delimiter=,') }}"
+PACKAGEMANAGEROPTIONS="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + ini_csv_file + ' col=3 delimiter=,') }}"
 
 # If the --downloadonly option is available then updates will be downloaded
 # during --prep
@@ -27,14 +27,14 @@ PREDOWNLOADUPDATES="yes"
 # NOTE: The PREDOWNLOADUPDATES must be set to "yes" for this to take effect.
 # The directory must be owned by user and group 'root' and must not be writable
 # by other.
-ONLYINSTALLFROMPREP="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=5 delimiter=,') }}"
+ONLYINSTALLFROMPREP="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + ini_csv_file + ' col=5 delimiter=,') }}"
 
 # MAXDELAY is upper limit of a random time to wait before querying repositories.
 # This applies to downloading updates (--prep) and installing updates (--apply).
 # This is used to stagger load on the repository servers. Default is
 # 3600 seconds so yum/dnf waits a random time between 1 and 3600 seconds.
 # Value is set in seconds
-MAXDELAY="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + csv_file + ' col=4 delimiter=,') }}"
+MAXDELAY="{{ lookup('csvfile', inventory_hostname.split(':')[0] + ' file=' + ini_csv_file + ' col=4 delimiter=,') }}"
 
 # Directories containing scripts to execute before/after updates are applied, 
 # and before/after a reboot (if applicable)


### PR DESCRIPTION
Fix for `auter_installer` role when run from `auter_installer.yml` playbook (variable `ini_csv_file`).

Removing pre_task block from `auter_manager.yml` file.
