### PR TITLE
corrected rs-epel name and removed result.failures invalid check

### DIFF
--- a/roles/auter_installer/tasks/prepare.yml
+++ b/roles/auter_installer/tasks/prepare.yml
@@ -23,7 +23,7 @@
   failed_when: False
   register: result
   yum:
-    name: rs-epel-release
+    name: epel-release-rackspace
     state: latest
   when: epelPresent.stdout|int == 0
 
@@ -34,7 +34,6 @@
     state: latest
   when: >
     epelPresent.stdout|int == 0 and
-    ("no package" in result.msg|lower or
-    "no package" in result.failures|lower)
+    "no package" in result.msg|lower
 
 ...


### PR DESCRIPTION
Corrected name of rackspace epel repo. 
result.failures dict doesn't exist anymore so not a valid check anymore